### PR TITLE
ci: Add new workflow for governor token list update

### DIFF
--- a/.github/workflows/governor-token-list.yml
+++ b/.github/workflows/governor-token-list.yml
@@ -1,0 +1,61 @@
+name: Governor Token List Update
+on:
+  schedule:
+    - cron: '0 0 1,15 * *' # Run at 00:00 on the 1st and 15th of every month
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  token-list-update:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.20.10"
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - name: Generate new token list
+        env:
+          PRICE_TOLERANCE: "50" # Price tolerance in %. Feel free to change this number.
+        run: |
+          cd node/hack/governor
+          npm ci
+          npm run start
+      - name: Verify new token list
+        run: |
+          cd node/hack/governor
+          go run check_query.go
+      - name: Run Governor tests
+        run: |
+          cd node/pkg/governor
+          go test
+      # IF UPSTREAMING IN THE FUTURE, REMOVE THE NEXT 2 STEPS
+      - name: Commit changes
+        uses: EndBug/add-and-commit@1bad3abcf0d6ec49a5857d124b0bfb52dc7bb081
+        with:
+          message: "node: governor token list update"
+          new_branch: node/governor-token-list-update
+      - name: Create Pull Request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GOVERNOR_TOKEN_LIST_UPDATE_SECRET }}
+        run: |
+          gh pr create \
+          --repo wormhole-foundation/wormhole \
+          --base main \
+          --head djb15:node/governor-token-list-update \
+          --title "node: Governor token list update" \
+          --body-file ./node/hack/governor/changes.txt
+      # IF UPSTREAMING IN THE FUTURE, UNCOMMENT THE STEP BELOW
+      # - name: Create Pull Request
+      #   uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38
+      #   with:
+      #     commit-message: "node: governor token list update"
+      #     body-path: ./node/hack/governor/changes.txt
+      #     title: 'node: Governor token list update'
+      #     branch: node/governor-token-list-update
+      #     base: main
+      #     delete-branch: true


### PR DESCRIPTION
This GH action will run on the 1st and 15th of every month.

It will run the token list update script and open a PR on the upstream repo. This script lives in a downstream repo to avoid having to be overly permissive with github actions permissions in the upstream repo. It can be moved to another organisation repo at a later date if desired.